### PR TITLE
config: add sslmode `verify-ca` and `verify-full`

### DIFF
--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -34,7 +34,8 @@ use tokio_postgres::{Error, Socket};
 /// * `options` - Command line options used to configure the server.
 /// * `application_name` - Sets the `application_name` parameter on the server.
 /// * `sslmode` - Controls usage of TLS. If set to `disable`, TLS will not be used. If set to `prefer`, TLS will be used
-///     if available, but not used otherwise. If set to `require`, TLS will be forced to be used. Defaults to `prefer`.
+///     if available, but not used otherwise. If set to `require`, `verify-ca`, or `verify-full`, TLS will be forced to
+///     be used. Defaults to `prefer`.
 /// * `host` - The host to connect to. On Unix platforms, if the host starts with a `/` character it is treated as the
 ///     path to the directory containing Unix domain sockets. Otherwise, it is treated as a hostname. Multiple hosts
 ///     can be specified, separated by commas. Each host will be tried in turn when connecting. Required if connecting

--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -5,11 +5,11 @@
 use crate::connection::Connection;
 use crate::Client;
 use log::info;
-use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
+use std::{fmt, path::PathBuf};
 use tokio::runtime;
 #[doc(inline)]
 pub use tokio_postgres::config::{ChannelBinding, Host, SslMode, TargetSessionAttrs};
@@ -33,9 +33,12 @@ use tokio_postgres::{Error, Socket};
 /// * `dbname` - The name of the database to connect to. Defaults to the username.
 /// * `options` - Command line options used to configure the server.
 /// * `application_name` - Sets the `application_name` parameter on the server.
+/// * `sslcert` - Location of the client SSL certificate file.
+/// * `sslkey` - Location for the secret key file used for the client certificate.
 /// * `sslmode` - Controls usage of TLS. If set to `disable`, TLS will not be used. If set to `prefer`, TLS will be used
 ///     if available, but not used otherwise. If set to `require`, `verify-ca`, or `verify-full`, TLS will be forced to
 ///     be used. Defaults to `prefer`.
+/// * `sslrootcert` - Location of SSL certificate authority (CA) certificate.
 /// * `host` - The host to connect to. On Unix platforms, if the host starts with a `/` character it is treated as the
 ///     path to the directory containing Unix domain sockets. Otherwise, it is treated as a hostname. Multiple hosts
 ///     can be specified, separated by commas. Each host will be tried in turn when connecting. Required if connecting
@@ -184,6 +187,32 @@ impl Config {
         self.config.get_application_name()
     }
 
+    /// Sets the location of the client SSL certificate file.
+    ///
+    /// Defaults to `None`.
+    pub fn ssl_cert(&mut self, ssl_cert: &str) -> &mut Config {
+        self.config.ssl_cert(ssl_cert);
+        self
+    }
+
+    /// Gets the location of the client SSL certificate file.
+    pub fn get_ssl_cert(&self) -> Option<PathBuf> {
+        self.config.get_ssl_cert()
+    }
+
+    /// Sets the location of the secret key file used for the client certificate.
+    ///
+    /// Defaults to `None`.
+    pub fn ssl_key(&mut self, ssl_key: &str) -> &mut Config {
+        self.config.ssl_key(ssl_key);
+        self
+    }
+
+    /// Gets the location of the secret key file used for the client certificate.
+    pub fn get_ssl_key(&self) -> Option<PathBuf> {
+        self.config.get_ssl_key()
+    }
+
     /// Sets the SSL configuration.
     ///
     /// Defaults to `prefer`.
@@ -195,6 +224,19 @@ impl Config {
     /// Gets the SSL configuration.
     pub fn get_ssl_mode(&self) -> SslMode {
         self.config.get_ssl_mode()
+    }
+
+    /// Sets the location of SSL certificate authority (CA) certificate.
+    ///
+    /// Defaults to `None`.
+    pub fn ssl_root_cert(&mut self, ssl_root_cert: &str) -> &mut Config {
+        self.config.ssl_root_cert(ssl_root_cert);
+        self
+    }
+
+    /// Gets the location of SSL certificate authority (CA) certificate.
+    pub fn get_ssl_root_cert(&self) -> Option<PathBuf> {
+        self.config.get_ssl_root_cert()
     }
 
     /// Adds a host to the configuration.

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -42,6 +42,10 @@ pub enum SslMode {
     Prefer,
     /// Require the use of TLS.
     Require,
+    /// Require the use of TLS.
+    VerifyCa,
+    /// Require the use of TLS.
+    VerifyFull,
 }
 
 /// Channel binding configuration.
@@ -95,7 +99,8 @@ pub enum Host {
 /// * `options` - Command line options used to configure the server.
 /// * `application_name` - Sets the `application_name` parameter on the server.
 /// * `sslmode` - Controls usage of TLS. If set to `disable`, TLS will not be used. If set to `prefer`, TLS will be used
-///     if available, but not used otherwise. If set to `require`, TLS will be forced to be used. Defaults to `prefer`.
+///     if available, but not used otherwise. If set to `require`, `verify-ca`, or `verify-full`, TLS will be forced to
+///     be used. Defaults to `prefer`.
 /// * `host` - The host to connect to. On Unix platforms, if the host starts with a `/` character it is treated as the
 ///     path to the directory containing Unix domain sockets. Otherwise, it is treated as a hostname. Multiple hosts
 ///     can be specified, separated by commas. Each host will be tried in turn when connecting. Required if connecting
@@ -432,6 +437,8 @@ impl Config {
                     "disable" => SslMode::Disable,
                     "prefer" => SslMode::Prefer,
                     "require" => SslMode::Require,
+                    "verify-ca" => SslMode::VerifyCa,
+                    "verify-full" => SslMode::VerifyFull,
                     _ => return Err(Error::config_parse(Box::new(InvalidValue("sslmode")))),
                 };
                 self.ssl_mode(mode);


### PR DESCRIPTION
I first tried to solve this on the Materialize side by parsing and "cleaning" the connection string before handing it to the Postgres client, but it added quite a bit of parsing complexity (e.g. connection strings come in URL and param list format, params can be quoted, there are escape sequences).

I think that having these additions in our fork is the simplest and most robust way of doing it without adding too much of a maintenance burden (the touched files should not change frequently). In addition, there is a [discussion on the upstream client repo](https://github.com/sfackler/rust-postgres/pull/774#discussion_r635199367) to contribute these changes upstream.