### PR TITLE
lib: add pub export for CopyBothDuplex struct

### DIFF
--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -121,6 +121,7 @@ pub use crate::cancel_token::CancelToken;
 pub use crate::client::Client;
 pub use crate::config::Config;
 pub use crate::connection::Connection;
+pub use crate::copy_both::CopyBothDuplex;
 pub use crate::copy_in::CopyInSink;
 pub use crate::copy_out::CopyOutStream;
 use crate::error::DbError;


### PR DESCRIPTION
Not sure if there's a reason not to export it, but it can be helpful for some project to export CopyBothDuplex.