### PR TITLE
Make some fields public

### DIFF
--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -1154,7 +1154,7 @@ impl LogicalReplicationMessage {
 
 /// A row as it appears in the replication stream
 #[derive(Debug)]
-pub struct Tuple(Vec<TupleData>);
+pub struct Tuple(pub Vec<TupleData>);
 
 impl Tuple {
     #[inline]
@@ -1367,7 +1367,7 @@ pub struct RelationBody {
     namespace: Bytes,
     name: Bytes,
     replica_identity: ReplicaIdentity,
-    columns: Vec<Column>,
+    pub columns: Vec<Column>,
 }
 
 impl RelationBody {
@@ -1434,7 +1434,7 @@ impl TypeBody {
 #[derive(Debug)]
 pub struct InsertBody {
     rel_id: u32,
-    tuple: Tuple,
+    pub tuple: Tuple,
 }
 
 impl InsertBody {
@@ -1455,9 +1455,9 @@ impl InsertBody {
 #[derive(Debug)]
 pub struct UpdateBody {
     rel_id: u32,
-    old_tuple: Option<Tuple>,
-    key_tuple: Option<Tuple>,
-    new_tuple: Tuple,
+    pub old_tuple: Option<Tuple>,
+    pub key_tuple: Option<Tuple>,
+    pub new_tuple: Tuple,
 }
 
 impl UpdateBody {
@@ -1492,8 +1492,8 @@ impl UpdateBody {
 #[derive(Debug)]
 pub struct DeleteBody {
     rel_id: u32,
-    old_tuple: Option<Tuple>,
-    key_tuple: Option<Tuple>,
+    pub old_tuple: Option<Tuple>,
+    pub key_tuple: Option<Tuple>,
 }
 
 impl DeleteBody {


### PR DESCRIPTION
It is impossible to move values from parsed messages, since everything is available only by a reference. This dumb PR just makes the complex fields public, so that the user does not have to clone all the data. Other implementations are welcome