### PR TITLE
add tcp user timeout config knob

### DIFF
--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -56,7 +56,7 @@ phf = "0.11"
 postgres-protocol = { version = "0.6.4", path = "../postgres-protocol" }
 postgres-types = { version = "0.2.4", path = "../postgres-types" }
 serde = { version = "1.0", optional = true }
-socket2 = "0.4"
+socket2 = { version = "0.4.7", features = ["all"] }
 tokio = { version = "1.0", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 

--- a/tokio-postgres/src/cancel_query.rs
+++ b/tokio-postgres/src/cancel_query.rs
@@ -38,6 +38,7 @@ where
         &config.host,
         config.port,
         config.connect_timeout,
+        config.user_timeout,
         config.keepalive.as_ref(),
     )
     .await?;

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -158,6 +158,7 @@ pub(crate) struct SocketConfig {
     pub host: Host,
     pub port: u16,
     pub connect_timeout: Option<Duration>,
+    pub user_timeout: Option<Duration>,
     pub keepalive: Option<KeepaliveConfig>,
 }
 

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -183,6 +183,7 @@ pub struct Config {
     pub(crate) host: Vec<Host>,
     pub(crate) port: Vec<u16>,
     pub(crate) connect_timeout: Option<Duration>,
+    pub(crate) user_timeout: Option<Duration>,
     pub(crate) keepalives: bool,
     pub(crate) keepalive_config: KeepaliveConfig,
     pub(crate) target_session_attrs: TargetSessionAttrs,
@@ -217,6 +218,7 @@ impl Config {
             host: vec![],
             port: vec![],
             connect_timeout: None,
+            user_timeout: None,
             keepalives: true,
             keepalive_config,
             target_session_attrs: TargetSessionAttrs::Any,
@@ -405,6 +407,18 @@ impl Config {
     /// `connect_timeout` method.
     pub fn get_connect_timeout(&self) -> Option<&Duration> {
         self.connect_timeout.as_ref()
+    }
+
+    /// Sets the TCP user timeout.
+    pub fn user_timeout(&mut self, user_timeout: Duration) -> &mut Config {
+        self.user_timeout = Some(user_timeout);
+        self
+    }
+
+    /// Gets the TCP user timeout, if one has been set with the
+    /// `user_timeout` method.
+    pub fn get_user_timeout(&self) -> Option<&Duration> {
+        self.user_timeout.as_ref()
     }
 
     /// Controls the use of TCP keepalive.

--- a/tokio-postgres/src/connect.rs
+++ b/tokio-postgres/src/connect.rs
@@ -65,6 +65,7 @@ where
         host,
         port,
         config.connect_timeout,
+        config.user_timeout,
         if config.keepalives {
             Some(&config.keepalive_config)
         } else {
@@ -118,6 +119,7 @@ where
         host: host.clone(),
         port,
         connect_timeout: config.connect_timeout,
+        user_timeout: config.user_timeout,
         keepalive: if config.keepalives {
             Some(config.keepalive_config.clone())
         } else {

--- a/tokio-postgres/src/connect_socket.rs
+++ b/tokio-postgres/src/connect_socket.rs
@@ -10,10 +10,12 @@ use tokio::net::UnixStream;
 use tokio::net::{self, TcpStream};
 use tokio::time;
 
+#[allow(unused_variables)]
 pub(crate) async fn connect_socket(
     host: &Host,
     port: u16,
     connect_timeout: Option<Duration>,
+    user_timeout: Option<Duration>,
     keepalive_config: Option<&KeepaliveConfig>,
 ) -> Result<Socket, Error> {
     match host {
@@ -35,8 +37,18 @@ pub(crate) async fn connect_socket(
                     };
 
                 stream.set_nodelay(true).map_err(Error::connect)?;
+
+                let sock_ref = SockRef::from(&stream);
+
+                #[cfg(target_os = "linux")]
+                {
+                    sock_ref
+                        .set_tcp_user_timeout(user_timeout)
+                        .map_err(Error::timeout)?;
+                }
+
                 if let Some(keepalive_config) = keepalive_config {
-                    SockRef::from(&stream)
+                    sock_ref
                         .set_tcp_keepalive(&TcpKeepalive::from(keepalive_config))
                         .map_err(Error::connect)?;
                 }

--- a/tokio-postgres/src/error/mod.rs
+++ b/tokio-postgres/src/error/mod.rs
@@ -503,6 +503,11 @@ impl Error {
         Error::new(Kind::Connect, Some(Box::new(e)))
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn timeout(e: io::Error) -> Error {
+        Error::new(Kind::Timeout, Some(Box::new(e)))
+    }
+
     #[doc(hidden)]
     pub fn __private_api_timeout() -> Error {
         Error::new(Kind::Timeout, None)


### PR DESCRIPTION
Currently tokio-postgres exposes two knobs to maintain healthy connections: a connect timeout and keep-alives settings that apply directly to the TCP socket. These cover the cases of connection establishment and for maintaining idle connections, but do not cover the case of an active/established socket that does not hear a response from the receiver for a long period of time. By default it can take 15-20m (15 retries with exponential backoff. the # of retries is controlled by `tcp_retries2`) for a connection to be killed under these circumstances.

The generally recommended solution to this problem is to set `TCP_USER_TIMEOUT` to cap the total amount of time a socket waits to receive a response after it is established. https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/ has a great writeup of this case under "Busy ESTAB socket is not forever".

I haven't found a super satisfying way of testing this yet, but staging it here for now.