### PR TITLE
add mutable access to the hosts in the config

### DIFF
--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -375,6 +375,11 @@ impl Config {
         &self.host
     }
 
+    /// Gets a mutable view of the hosts that have been added to the configuration with `host`.
+    pub fn get_hosts_mut(&mut self) -> &mut [Host] {
+        &mut self.host
+    }
+
     /// Sets the hostname used during TLS certificate verification, if enabled.
     ///
     /// This can be useful if you are connecting through an SSH tunnel.


### PR DESCRIPTION
@benesch in https://github.com/MaterializeInc/materialize/pull/23589 in we need to set the singular _host_ to the privatelink host, but set the `tls_verify_host` to the original one.

Currently the `Config` struct doesn't let us mutate hosts to do this just add them, so I added mutable access