### PR TITLE
Integrate upstream hostaddr/load balancing support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: sfackler/actions/rustup@master
       - uses: sfackler/actions/rustfmt@master
-  
+
   clippy:
     name: clippy
     runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
       - run: docker compose up -d
       - uses: sfackler/actions/rustup@master
         with:
-          version: 1.64.0
+          version: 1.77.0
       - run: echo "version=$(rustc --version)" >> $GITHUB_OUTPUT
         id: rust-version
       - uses: actions/cache@v3

--- a/postgres-protocol/src/types/test.rs
+++ b/postgres-protocol/src/types/test.rs
@@ -174,7 +174,7 @@ fn ltree_str() {
     let mut query = vec![1u8];
     query.extend_from_slice("A.B.C".as_bytes());
 
-    assert!(matches!(ltree_from_sql(query.as_slice()), Ok(_)))
+    assert!(ltree_from_sql(query.as_slice()).is_ok())
 }
 
 #[test]
@@ -182,7 +182,7 @@ fn ltree_wrong_version() {
     let mut query = vec![2u8];
     query.extend_from_slice("A.B.C".as_bytes());
 
-    assert!(matches!(ltree_from_sql(query.as_slice()), Err(_)))
+    assert!(ltree_from_sql(query.as_slice()).is_err())
 }
 
 #[test]
@@ -202,7 +202,7 @@ fn lquery_str() {
     let mut query = vec![1u8];
     query.extend_from_slice("A.B.C".as_bytes());
 
-    assert!(matches!(lquery_from_sql(query.as_slice()), Ok(_)))
+    assert!(lquery_from_sql(query.as_slice()).is_ok())
 }
 
 #[test]
@@ -210,7 +210,7 @@ fn lquery_wrong_version() {
     let mut query = vec![2u8];
     query.extend_from_slice("A.B.C".as_bytes());
 
-    assert!(matches!(lquery_from_sql(query.as_slice()), Err(_)))
+    assert!(lquery_from_sql(query.as_slice()).is_err())
 }
 
 #[test]
@@ -230,7 +230,7 @@ fn ltxtquery_str() {
     let mut query = vec![1u8];
     query.extend_from_slice("a & b*".as_bytes());
 
-    assert!(matches!(ltree_from_sql(query.as_slice()), Ok(_)))
+    assert!(ltree_from_sql(query.as_slice()).is_ok())
 }
 
 #[test]
@@ -238,5 +238,5 @@ fn ltxtquery_wrong_version() {
     let mut query = vec![2u8];
     query.extend_from_slice("a & b*".as_bytes());
 
-    assert!(matches!(ltree_from_sql(query.as_slice()), Err(_)))
+    assert!(ltree_from_sql(query.as_slice()).is_err())
 }

--- a/postgres-types/src/chrono_04.rs
+++ b/postgres-types/src/chrono_04.rs
@@ -40,7 +40,7 @@ impl ToSql for NaiveDateTime {
 impl<'a> FromSql<'a> for DateTime<Utc> {
     fn from_sql(type_: &Type, raw: &[u8]) -> Result<DateTime<Utc>, Box<dyn Error + Sync + Send>> {
         let naive = NaiveDateTime::from_sql(type_, raw)?;
-        Ok(DateTime::from_utc(naive, Utc))
+        Ok(DateTime::from_naive_utc_and_offset(naive, Utc))
     }
 
     accepts!(TIMESTAMPTZ);
@@ -111,7 +111,7 @@ impl<'a> FromSql<'a> for NaiveDate {
         let jd = types::date_from_sql(raw)?;
         base()
             .date()
-            .checked_add_signed(Duration::days(i64::from(jd)))
+            .checked_add_signed(Duration::try_days(i64::from(jd)).unwrap())
             .ok_or_else(|| "value too large to decode".into())
     }
 

--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -6,6 +6,7 @@ use crate::connection::Connection;
 use crate::Client;
 use log::info;
 use std::fmt;
+use std::net::IpAddr;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -43,6 +44,19 @@ use tokio_postgres::{Error, Socket};
 ///     path to the directory containing Unix domain sockets. Otherwise, it is treated as a hostname. Multiple hosts
 ///     can be specified, separated by commas. Each host will be tried in turn when connecting. Required if connecting
 ///     with the `connect` method.
+/// * `hostaddr` - Numeric IP address of host to connect to. This should be in the standard IPv4 address format,
+///     e.g., 172.28.40.9. If your machine supports IPv6, you can also use those addresses.
+///     If this parameter is not specified, the value of `host` will be looked up to find the corresponding IP address,
+///     - or if host specifies an IP address, that value will be used directly.
+///     Using `hostaddr` allows the application to avoid a host name look-up, which might be important in applications
+///     with time constraints. However, a host name is required for verify-full SSL certificate verification.
+///     Specifically:
+///         * If `hostaddr` is specified without `host`, the value for `hostaddr` gives the server network address.
+///             The connection attempt will fail if the authentication method requires a host name;
+///         * If `host` is specified without `hostaddr`, a host name lookup occurs;
+///         * If both `host` and `hostaddr` are specified, the value for `hostaddr` gives the server network address.
+///             The value for `host` is ignored unless the authentication method requires it,
+///             in which case it will be used as the host name.
 /// * `port` - The port to connect to. Multiple ports can be specified, separated by commas. The number of ports must be
 ///     either 1, in which case it will be used for all hosts, or the same as the number of hosts. Defaults to 5432 if
 ///     omitted or the empty string.
@@ -71,6 +85,10 @@ use tokio_postgres::{Error, Socket};
 ///
 /// ```not_rust
 /// host=/var/run/postgresql,localhost port=1234 user=postgres password='password with spaces'
+/// ```
+///
+/// ```not_rust
+/// host=host1,host2,host3 port=1234,,5678 hostaddr=127.0.0.1,127.0.0.2,127.0.0.3 user=postgres target_session_attrs=read-write
 /// ```
 ///
 /// ```not_rust
@@ -250,6 +268,7 @@ impl Config {
     ///
     /// Multiple hosts can be specified by calling this method multiple times, and each will be tried in order. On Unix
     /// systems, a host starting with a `/` is interpreted as a path to a directory containing Unix domain sockets.
+    /// There must be either no hosts, or the same number of hosts as hostaddrs.
     pub fn host(&mut self, host: &str) -> &mut Config {
         self.config.host(host);
         self
@@ -258,6 +277,11 @@ impl Config {
     /// Gets the hosts that have been added to the configuration with `host`.
     pub fn get_hosts(&self) -> &[Host] {
         self.config.get_hosts()
+    }
+
+    /// Gets the hostaddrs that have been added to the configuration with `hostaddr`.
+    pub fn get_hostaddrs(&self) -> &[IpAddr] {
+        self.config.get_hostaddrs()
     }
 
     /// Adds a Unix socket host to the configuration.
@@ -269,6 +293,15 @@ impl Config {
         T: AsRef<Path>,
     {
         self.config.host_path(host);
+        self
+    }
+
+    /// Adds a hostaddr to the configuration.
+    ///
+    /// Multiple hostaddrs can be specified by calling this method multiple times, and each will be tried in order.
+    /// There must be either no hostaddrs, or the same number of hostaddrs as hosts.
+    pub fn hostaddr(&mut self, hostaddr: IpAddr) -> &mut Config {
+        self.config.hostaddr(hostaddr);
         self
     }
 

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -79,7 +79,6 @@ eui48-04 = { version = "0.4", package = "eui48" }
 eui48-1 = { version = "1.0", package = "eui48" }
 geo-types-06 = { version = "0.6", package = "geo-types" }
 geo-types-07 = { version = "0.7", package = "geo-types" }
-serde-1 = { version = "1.0", package = "serde" }
 serde_json-1 = { version = "1.0", package = "serde_json" }
 smol_str-01 = { version = "0.1", package = "smol_str" }
 uuid-08 = { version = "0.8", package = "uuid" }

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -59,6 +59,7 @@ serde = { version = "1.0", optional = true }
 socket2 = { version = "0.5", features = ["all"] }
 tokio = { version = "1.27", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }
+rand = "0.8.5"
 
 [dev-dependencies]
 futures-executor = "0.3"

--- a/tokio-postgres/src/cancel_query.rs
+++ b/tokio-postgres/src/cancel_query.rs
@@ -1,5 +1,5 @@
 use crate::client::SocketConfig;
-use crate::config::{Host, SslMode};
+use crate::config::SslMode;
 use crate::tls::MakeTlsConnect;
 use crate::{cancel_query_raw, connect_socket, Error, Socket};
 use std::io;
@@ -24,18 +24,13 @@ where
         }
     };
 
-    let hostname = match &config.host {
-        Host::Tcp(host) => &**host,
-        // postgres doesn't support TLS over unix sockets, so the choice here doesn't matter
-        #[cfg(unix)]
-        Host::Unix(_) => "",
-    };
     let tls = tls
-        .make_tls_connect(hostname)
+        .make_tls_connect(config.hostname.as_deref().unwrap_or(""))
         .map_err(|e| Error::tls(e.into()))?;
+    let has_hostname = config.hostname.is_some();
 
     let socket = connect_socket::connect_socket(
-        &config.host,
+        &config.addr,
         config.port,
         config.connect_timeout,
         config.tcp_user_timeout,
@@ -43,5 +38,6 @@ where
     )
     .await?;
 
-    cancel_query_raw::cancel_query_raw(socket, ssl_mode, tls, process_id, secret_key).await
+    cancel_query_raw::cancel_query_raw(socket, ssl_mode, tls, has_hostname, process_id, secret_key)
+        .await
 }

--- a/tokio-postgres/src/cancel_query_raw.rs
+++ b/tokio-postgres/src/cancel_query_raw.rs
@@ -9,6 +9,7 @@ pub async fn cancel_query_raw<S, T>(
     stream: S,
     mode: SslMode,
     tls: T,
+    has_hostname: bool,
     process_id: i32,
     secret_key: i32,
 ) -> Result<(), Error>
@@ -16,7 +17,7 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
     T: TlsConnect<S>,
 {
-    let mut stream = connect_tls::connect_tls(stream, mode, tls).await?;
+    let mut stream = connect_tls::connect_tls(stream, mode, tls, has_hostname).await?;
 
     let mut buf = BytesMut::new();
     frontend::cancel_request(process_id, secret_key, &mut buf);

--- a/tokio-postgres/src/cancel_token.rs
+++ b/tokio-postgres/src/cancel_token.rs
@@ -55,6 +55,7 @@ impl CancelToken {
             stream,
             self.ssl_mode,
             tls,
+            true,
             self.process_id,
             self.secret_key,
         )

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -27,7 +27,9 @@ use postgres_protocol::message::{backend::Message, frontend};
 use postgres_types::BorrowToSql;
 use std::collections::HashMap;
 use std::fmt;
+#[cfg(feature = "runtime")]
 use std::net::IpAddr;
+#[cfg(feature = "runtime")]
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::task::{Context, Poll};

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -1,6 +1,4 @@
 use crate::codec::{BackendMessages, FrontendMessage};
-#[cfg(feature = "runtime")]
-use crate::config::Host;
 use crate::config::SslMode;
 use crate::connection::{Request, RequestMessages};
 use crate::copy_both::CopyBothDuplex;
@@ -29,6 +27,8 @@ use postgres_protocol::message::{backend::Message, frontend};
 use postgres_types::BorrowToSql;
 use std::collections::HashMap;
 use std::fmt;
+use std::net::IpAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 #[cfg(feature = "runtime")]
@@ -155,11 +155,20 @@ impl InnerClient {
 #[cfg(feature = "runtime")]
 #[derive(Clone)]
 pub(crate) struct SocketConfig {
-    pub host: Host,
+    pub addr: Addr,
+    pub hostname: Option<String>,
     pub port: u16,
     pub connect_timeout: Option<Duration>,
     pub tcp_user_timeout: Option<Duration>,
     pub keepalive: Option<KeepaliveConfig>,
+}
+
+#[cfg(feature = "runtime")]
+#[derive(Clone)]
+pub(crate) enum Addr {
+    Tcp(IpAddr),
+    #[cfg(unix)]
+    Unix(PathBuf),
 }
 
 /// An asynchronous PostgreSQL client.

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -195,7 +195,6 @@ pub struct Config {
     pub(crate) target_session_attrs: TargetSessionAttrs,
     pub(crate) channel_binding: ChannelBinding,
     pub(crate) replication_mode: Option<ReplicationMode>,
-    pub(crate) tls_verify_host: Option<String>,
 }
 
 impl Default for Config {
@@ -231,7 +230,6 @@ impl Config {
             target_session_attrs: TargetSessionAttrs::Any,
             channel_binding: ChannelBinding::Prefer,
             replication_mode: None,
-            tls_verify_host: None,
         }
     }
 
@@ -375,22 +373,10 @@ impl Config {
         &self.host
     }
 
-    /// Gets a mutable view of the hosts that have been added to the configuration with `host`.
+    /// Gets a mutable view of the hosts that have been added to the
+    /// configuration with `host`.
     pub fn get_hosts_mut(&mut self) -> &mut [Host] {
         &mut self.host
-    }
-
-    /// Sets the hostname used during TLS certificate verification, if enabled.
-    ///
-    /// This can be useful if you are connecting through an SSH tunnel.
-    pub fn tls_verify_host(&mut self, host: &str) -> &mut Config {
-        self.tls_verify_host = Some(host.to_string());
-        self
-    }
-
-    /// Gets the host that has been added to the configuration with `tls_verify_host`.
-    pub fn get_tls_verify_host(&self) -> Option<&str> {
-        self.tls_verify_host.as_deref()
     }
 
     /// Adds a Unix socket host to the configuration.

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -622,7 +622,7 @@ impl Config {
             "application_name" => {
                 self.application_name(value);
             }
-            "sslcert" => match std::fs::read(&value) {
+            "sslcert" => match std::fs::read(value) {
                 Ok(contents) => {
                     self.ssl_cert(&contents);
                 }
@@ -633,7 +633,7 @@ impl Config {
             "sslcert_inline" => {
                 self.ssl_cert(value.as_bytes());
             }
-            "sslkey" => match std::fs::read(&value) {
+            "sslkey" => match std::fs::read(value) {
                 Ok(contents) => {
                     self.ssl_key(&contents);
                 }
@@ -655,7 +655,7 @@ impl Config {
                 };
                 self.ssl_mode(mode);
             }
-            "sslrootcert" => match std::fs::read(&value) {
+            "sslrootcert" => match std::fs::read(value) {
                 Ok(contents) => {
                     self.ssl_root_cert(&contents);
                 }

--- a/tokio-postgres/src/connect.rs
+++ b/tokio-postgres/src/connect.rs
@@ -32,12 +32,11 @@ where
             .copied()
             .unwrap_or(5432);
 
-        let hostname = match (config.tls_verify_host.as_deref(), host) {
-            (Some(tls_verify_host), Host::Tcp(_)) => tls_verify_host,
-            (None, Host::Tcp(host)) => host.as_str(),
+        let hostname = match host {
+            Host::Tcp(host) => host.as_str(),
             // postgres doesn't support TLS over unix sockets, so the choice here doesn't matter
             #[cfg(unix)]
-            (_, Host::Unix(_)) => "",
+            Host::Unix(_) => "",
         };
 
         let tls = tls

--- a/tokio-postgres/src/connect.rs
+++ b/tokio-postgres/src/connect.rs
@@ -1,12 +1,14 @@
-use crate::client::SocketConfig;
-use crate::config::{Host, TargetSessionAttrs};
+use crate::client::{Addr, SocketConfig};
+use crate::config::{Host, LoadBalanceHosts, TargetSessionAttrs};
 use crate::connect_raw::connect_raw;
 use crate::connect_socket::connect_socket;
-use crate::tls::{MakeTlsConnect, TlsConnect};
+use crate::tls::MakeTlsConnect;
 use crate::{Client, Config, Connection, Error, SimpleQueryMessage, Socket};
 use futures_util::{future, pin_mut, Future, FutureExt, Stream};
-use std::io;
+use rand::seq::SliceRandom;
 use std::task::Poll;
+use std::{cmp, io};
+use tokio::net;
 
 pub async fn connect<T>(
     mut tls: T,
@@ -15,16 +17,40 @@ pub async fn connect<T>(
 where
     T: MakeTlsConnect<Socket>,
 {
-    if config.host.is_empty() {
-        return Err(Error::config("host missing".into()));
+    if config.host.is_empty() && config.hostaddr.is_empty() {
+        return Err(Error::config("both host and hostaddr are missing".into()));
     }
 
-    if config.port.len() > 1 && config.port.len() != config.host.len() {
+    if !config.host.is_empty()
+        && !config.hostaddr.is_empty()
+        && config.host.len() != config.hostaddr.len()
+    {
+        let msg = format!(
+            "number of hosts ({}) is different from number of hostaddrs ({})",
+            config.host.len(),
+            config.hostaddr.len(),
+        );
+        return Err(Error::config(msg.into()));
+    }
+
+    // At this point, either one of the following two scenarios could happen:
+    // (1) either config.host or config.hostaddr must be empty;
+    // (2) if both config.host and config.hostaddr are NOT empty; their lengths must be equal.
+    let num_hosts = cmp::max(config.host.len(), config.hostaddr.len());
+
+    if config.port.len() > 1 && config.port.len() != num_hosts {
         return Err(Error::config("invalid number of ports".into()));
     }
 
+    let mut indices = (0..num_hosts).collect::<Vec<_>>();
+    if config.load_balance_hosts == LoadBalanceHosts::Random {
+        indices.shuffle(&mut rand::thread_rng());
+    }
+
     let mut error = None;
-    for (i, host) in config.host.iter().enumerate() {
+    for i in indices {
+        let host = config.host.get(i);
+        let hostaddr = config.hostaddr.get(i);
         let port = config
             .port
             .get(i)
@@ -32,18 +58,23 @@ where
             .copied()
             .unwrap_or(5432);
 
+        // The value of host is used as the hostname for TLS validation,
         let hostname = match host {
-            Host::Tcp(host) => host.as_str(),
+            Some(Host::Tcp(host)) => Some(host.clone()),
             // postgres doesn't support TLS over unix sockets, so the choice here doesn't matter
             #[cfg(unix)]
-            Host::Unix(_) => "",
+            Some(Host::Unix(_)) => None,
+            None => None,
         };
 
-        let tls = tls
-            .make_tls_connect(hostname)
-            .map_err(|e| Error::tls(e.into()))?;
+        // Try to use the value of hostaddr to establish the TCP connection,
+        // fallback to host if hostaddr is not present.
+        let addr = match hostaddr {
+            Some(ipaddr) => Host::Tcp(ipaddr.to_string()),
+            None => host.cloned().unwrap(),
+        };
 
-        match connect_once(host, port, tls, config).await {
+        match connect_host(addr, hostname, port, &mut tls, config).await {
             Ok((client, connection)) => return Ok((client, connection)),
             Err(e) => error = Some(e),
         }
@@ -52,17 +83,66 @@ where
     Err(error.unwrap())
 }
 
-async fn connect_once<T>(
-    host: &Host,
+async fn connect_host<T>(
+    host: Host,
+    hostname: Option<String>,
     port: u16,
-    tls: T,
+    tls: &mut T,
     config: &Config,
 ) -> Result<(Client, Connection<Socket, T::Stream>), Error>
 where
-    T: TlsConnect<Socket>,
+    T: MakeTlsConnect<Socket>,
+{
+    match host {
+        Host::Tcp(host) => {
+            let mut addrs = net::lookup_host((&*host, port))
+                .await
+                .map_err(Error::connect)?
+                .collect::<Vec<_>>();
+
+            if config.load_balance_hosts == LoadBalanceHosts::Random {
+                addrs.shuffle(&mut rand::thread_rng());
+            }
+
+            let mut last_err = None;
+            for addr in addrs {
+                match connect_once(Addr::Tcp(addr.ip()), hostname.as_deref(), port, tls, config)
+                    .await
+                {
+                    Ok(stream) => return Ok(stream),
+                    Err(e) => {
+                        last_err = Some(e);
+                        continue;
+                    }
+                };
+            }
+
+            Err(last_err.unwrap_or_else(|| {
+                Error::connect(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "could not resolve any addresses",
+                ))
+            }))
+        }
+        #[cfg(unix)]
+        Host::Unix(path) => {
+            connect_once(Addr::Unix(path), hostname.as_deref(), port, tls, config).await
+        }
+    }
+}
+
+async fn connect_once<T>(
+    addr: Addr,
+    hostname: Option<&str>,
+    port: u16,
+    tls: &mut T,
+    config: &Config,
+) -> Result<(Client, Connection<Socket, T::Stream>), Error>
+where
+    T: MakeTlsConnect<Socket>,
 {
     let socket = connect_socket(
-        host,
+        &addr,
         port,
         config.connect_timeout,
         config.tcp_user_timeout,
@@ -73,7 +153,12 @@ where
         },
     )
     .await?;
-    let (mut client, mut connection) = connect_raw(socket, tls, config).await?;
+
+    let tls = tls
+        .make_tls_connect(hostname.unwrap_or(""))
+        .map_err(|e| Error::tls(e.into()))?;
+    let has_hostname = hostname.is_some();
+    let (mut client, mut connection) = connect_raw(socket, tls, has_hostname, config).await?;
 
     if let TargetSessionAttrs::ReadWrite = config.target_session_attrs {
         let rows = client.simple_query_raw("SHOW transaction_read_only");
@@ -116,7 +201,8 @@ where
     }
 
     client.set_socket_config(SocketConfig {
-        host: host.clone(),
+        addr,
+        hostname: hostname.map(|s| s.to_string()),
         port,
         connect_timeout: config.connect_timeout,
         tcp_user_timeout: config.tcp_user_timeout,

--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -81,13 +81,14 @@ where
 pub async fn connect_raw<S, T>(
     stream: S,
     tls: T,
+    has_hostname: bool,
     config: &Config,
 ) -> Result<(Client, Connection<S, T::Stream>), Error>
 where
     S: AsyncRead + AsyncWrite + Unpin,
     T: TlsConnect<S>,
 {
-    let stream = connect_tls(stream, config.ssl_mode, tls).await?;
+    let stream = connect_tls(stream, config.ssl_mode, tls, has_hostname).await?;
 
     let mut stream = StartupStream {
         inner: Framed::new(stream, PostgresCodec),

--- a/tokio-postgres/src/connect_socket.rs
+++ b/tokio-postgres/src/connect_socket.rs
@@ -38,7 +38,7 @@ pub(crate) async fn connect_socket(
                     .map_err(Error::connect)?;
             }
 
-            return Ok(Socket::new_tcp(stream));
+            Ok(Socket::new_tcp(stream))
         }
         #[cfg(unix)]
         Addr::Unix(dir) => {

--- a/tokio-postgres/src/connect_socket.rs
+++ b/tokio-postgres/src/connect_socket.rs
@@ -1,69 +1,48 @@
-use crate::config::Host;
+use crate::client::Addr;
 use crate::keepalive::KeepaliveConfig;
 use crate::{Error, Socket};
 use socket2::{SockRef, TcpKeepalive};
 use std::future::Future;
 use std::io;
 use std::time::Duration;
+use tokio::net::TcpStream;
 #[cfg(unix)]
 use tokio::net::UnixStream;
-use tokio::net::{self, TcpStream};
 use tokio::time;
 
 pub(crate) async fn connect_socket(
-    host: &Host,
+    addr: &Addr,
     port: u16,
     connect_timeout: Option<Duration>,
     tcp_user_timeout: Option<Duration>,
     keepalive_config: Option<&KeepaliveConfig>,
 ) -> Result<Socket, Error> {
-    match host {
-        Host::Tcp(host) => {
-            let addrs = net::lookup_host((&**host, port))
-                .await
-                .map_err(Error::connect)?;
+    match addr {
+        Addr::Tcp(ip) => {
+            let stream =
+                connect_with_timeout(TcpStream::connect((*ip, port)), connect_timeout).await?;
 
-            let mut last_err = None;
+            stream.set_nodelay(true).map_err(Error::connect)?;
 
-            for addr in addrs {
-                let stream =
-                    match connect_with_timeout(TcpStream::connect(addr), connect_timeout).await {
-                        Ok(stream) => stream,
-                        Err(e) => {
-                            last_err = Some(e);
-                            continue;
-                        }
-                    };
-
-                stream.set_nodelay(true).map_err(Error::connect)?;
-
-                let sock_ref = SockRef::from(&stream);
-                #[cfg(target_os = "linux")]
-                {
-                    sock_ref
-                        .set_tcp_user_timeout(tcp_user_timeout)
-                        .map_err(Error::connect)?;
-                }
-
-                if let Some(keepalive_config) = keepalive_config {
-                    sock_ref
-                        .set_tcp_keepalive(&TcpKeepalive::from(keepalive_config))
-                        .map_err(Error::connect)?;
-                }
-
-                return Ok(Socket::new_tcp(stream));
+            let sock_ref = SockRef::from(&stream);
+            #[cfg(target_os = "linux")]
+            {
+                sock_ref
+                    .set_tcp_user_timeout(tcp_user_timeout)
+                    .map_err(Error::connect)?;
             }
 
-            Err(last_err.unwrap_or_else(|| {
-                Error::connect(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "could not resolve any addresses",
-                ))
-            }))
+            if let Some(keepalive_config) = keepalive_config {
+                sock_ref
+                    .set_tcp_keepalive(&TcpKeepalive::from(keepalive_config))
+                    .map_err(Error::connect)?;
+            }
+
+            return Ok(Socket::new_tcp(stream));
         }
         #[cfg(unix)]
-        Host::Unix(path) => {
-            let path = path.join(format!(".s.PGSQL.{}", port));
+        Addr::Unix(dir) => {
+            let path = dir.join(format!(".s.PGSQL.{}", port));
             let socket = connect_with_timeout(UnixStream::connect(path), connect_timeout).await?;
             Ok(Socket::new_unix(socket))
         }

--- a/tokio-postgres/src/connect_tls.rs
+++ b/tokio-postgres/src/connect_tls.rs
@@ -11,6 +11,7 @@ pub async fn connect_tls<S, T>(
     mut stream: S,
     mode: SslMode,
     tls: T,
+    has_hostname: bool,
 ) -> Result<MaybeTlsStream<S, T::Stream>, Error>
 where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -38,6 +39,10 @@ where
             }
             SslMode::Disable | SslMode::Prefer => return Ok(MaybeTlsStream::Raw(stream)),
         }
+    }
+
+    if !has_hostname {
+        return Err(Error::tls("no hostname provided for TLS handshake".into()));
     }
 
     let stream = tls

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -330,7 +330,7 @@ async fn simple_query() {
     }
     match &messages[2] {
         SimpleQueryMessage::Row(row) => {
-            assert_eq!(row.columns().get(0).map(|c| c.name()), Some("id"));
+            assert_eq!(row.columns().first().map(|c| c.name()), Some("id"));
             assert_eq!(row.columns().get(1).map(|c| c.name()), Some("name"));
             assert_eq!(row.get(0), Some("1"));
             assert_eq!(row.get(1), Some("steven"));
@@ -339,7 +339,7 @@ async fn simple_query() {
     }
     match &messages[3] {
         SimpleQueryMessage::Row(row) => {
-            assert_eq!(row.columns().get(0).map(|c| c.name()), Some("id"));
+            assert_eq!(row.columns().first().map(|c| c.name()), Some("id"));
             assert_eq!(row.columns().get(1).map(|c| c.name()), Some("name"));
             assert_eq!(row.get(0), Some("2"));
             assert_eq!(row.get(1), Some("joe"));

--- a/tokio-postgres/tests/test/runtime.rs
+++ b/tokio-postgres/tests/test/runtime.rs
@@ -67,6 +67,58 @@ async fn target_session_attrs_err() {
 }
 
 #[tokio::test]
+async fn host_only_ok() {
+    let _ = tokio_postgres::connect(
+        "host=localhost port=5433 user=pass_user dbname=postgres password=password",
+        NoTls,
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn hostaddr_only_ok() {
+    let _ = tokio_postgres::connect(
+        "hostaddr=127.0.0.1 port=5433 user=pass_user dbname=postgres password=password",
+        NoTls,
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn hostaddr_and_host_ok() {
+    let _ = tokio_postgres::connect(
+        "hostaddr=127.0.0.1 host=localhost port=5433 user=pass_user dbname=postgres password=password",
+        NoTls,
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn hostaddr_host_mismatch() {
+    let _ = tokio_postgres::connect(
+        "hostaddr=127.0.0.1,127.0.0.2 host=localhost port=5433 user=pass_user dbname=postgres password=password",
+        NoTls,
+    )
+    .await
+    .err()
+    .unwrap();
+}
+
+#[tokio::test]
+async fn hostaddr_host_both_missing() {
+    let _ = tokio_postgres::connect(
+        "port=5433 user=pass_user dbname=postgres password=password",
+        NoTls,
+    )
+    .await
+    .err()
+    .unwrap();
+}
+
+#[tokio::test]
 async fn cancel_query() {
     let client = connect("host=localhost port=5433 user=postgres").await;
 

--- a/tokio-postgres/tests/test/types/chrono_04.rs
+++ b/tokio-postgres/tests/test/types/chrono_04.rs
@@ -1,4 +1,4 @@
-use chrono_04::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
+use chrono_04::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use std::fmt;
 use tokio_postgres::types::{Date, FromSqlOwned, Timestamp};
 use tokio_postgres::Client;
@@ -54,8 +54,9 @@ async fn test_date_time_params() {
     fn make_check(time: &str) -> (Option<DateTime<Utc>>, &str) {
         (
             Some(
-                Utc.datetime_from_str(time, "'%Y-%m-%d %H:%M:%S.%f'")
-                    .unwrap(),
+                NaiveDateTime::parse_from_str(time, "'%Y-%m-%d %H:%M:%S.%f'")
+                    .unwrap()
+                    .and_utc(),
             ),
             time,
         )
@@ -77,8 +78,9 @@ async fn test_with_special_date_time_params() {
     fn make_check(time: &str) -> (Timestamp<DateTime<Utc>>, &str) {
         (
             Timestamp::Value(
-                Utc.datetime_from_str(time, "'%Y-%m-%d %H:%M:%S.%f'")
-                    .unwrap(),
+                NaiveDateTime::parse_from_str(time, "'%Y-%m-%d %H:%M:%S.%f'")
+                    .unwrap()
+                    .and_utc(),
             ),
             time,
         )


### PR DESCRIPTION
This is more flexible than our previous approach to allowing the TLS verify host to be overridden. In particular, users can specify multiple IPs to try for the same host, e.g.:

```rust
Config::new()
  .host("my-pg-server")
  .hostaddr(1.2.3.1)
  .host("my-pg-server")
  .hostaddr(1.2.3.2)
  .host("my-pg-server")
  .hostaddr(1.2.3.3)
```