### PR TITLE
buffer 16 messages in copy-both involved channels

### DIFF
--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -123,9 +123,9 @@ impl InnerClient {
     }
 
     pub fn start_copy_both(&self) -> Result<CopyBothHandles, Error> {
-        let (sender, receiver) = mpsc::channel(1);
-        let (stream_sender, stream_receiver) = mpsc::channel(0);
-        let (sink_sender, sink_receiver) = mpsc::channel(0);
+        let (sender, receiver) = mpsc::channel(16);
+        let (stream_sender, stream_receiver) = mpsc::channel(16);
+        let (sink_sender, sink_receiver) = mpsc::channel(16);
 
         let responses = Responses {
             receiver,


### PR DESCRIPTION
I noticed that I introduced a regression as part of https://github.com/MaterializeInc/rust-postgres/pull/25. I created a local benchmark and captured flamegraphs which indicated that a lot of time was spent parking and unparking threads and in general channel synchronization.

I don't know if this is due to the channel implementation of `futures_channel` being less efficient than say tokio's mpsc channels but increasing their capacity brings the performance back to previous levels since any synchronization overheads are now both amortized over more operations and parking is less likely to happen if both ends are continually draining the channels.